### PR TITLE
Use terse guard clause for git clone

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,9 +21,7 @@ set -x
 dockerd > /var/log/dockerd.log 2>&1 &
 sleep 3
 
-if [ ! -d "repo" ]; then
-  git clone --branch $_GIT_BRANCH $GIT_REPO_URL repo
-fi
+[ -d "repo" ] || git clone --branch $_GIT_BRANCH $GIT_REPO_URL repo
 cd repo/$RELATIVE_SUB_DIR
 
 docker build -t $DOCKER_IMAGE_NAME .


### PR DESCRIPTION
## Summary
- Replace verbose if statement with concise test operator syntax for git clone guard clause
- Makes the code more terse and consistent with other projects (e.g., regex-directed-graph-line-parser)

## Changes
```bash
# Before
if [ ! -d "repo" ]; then
  git clone --branch $_GIT_BRANCH $GIT_REPO_URL repo
fi

# After
[ -d "repo" ] || git clone --branch $_GIT_BRANCH $GIT_REPO_URL repo
```

## Test plan
- Build process should work identically
- Guard clause still prevents re-cloning if directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)